### PR TITLE
RFC Support capture events, fix custom events, support on/onCapture

### DIFF
--- a/src/jsx-dom.ts
+++ b/src/jsx-dom.ts
@@ -291,17 +291,28 @@ function attribute(key: string, value: any, node: Element & HTMLOrSVGElement) {
     case "style":
       style(node, value)
       return
+    case "on":
+    case "onCapture":
+      const useCapture = key === "onCapture"
+      forEach(value, (eventHandler, eventName) => {
+        node.addEventListener(eventName, eventHandler, useCapture)
+      })
+      return
     // fallthrough
   }
 
   if (isFunction(value)) {
     if (key[0] === "o" && key[1] === "n") {
       const attribute = key.toLowerCase()
-      // Issue #33
-      if (node[attribute] == null) {
+      const useCapture = attribute.endsWith("capture")
+
+      if (!useCapture && node[attribute] === null) {
+        // use property when possible PR #17
         node[attribute] = value
+      } else if (useCapture) {
+        node.addEventListener(attribute.substring(2, attribute.length - 7), value, true)
       } else {
-        node.addEventListener(key, value)
+        node.addEventListener(attribute.substring(2), value)
       }
     }
   } else if (isObject(value)) {

--- a/test/test-main.tsx
+++ b/test/test-main.tsx
@@ -352,6 +352,55 @@ describe("jsx-dom", () => {
       const button = (<button onClick={() => done()} />) as HTMLButtonElement
       button.click()
     })
+    it("supports capture event listeners", done => {
+      const button = (
+        <button
+          onClickCapture={event => {
+            event.stopImmediatePropagation()
+            done()
+          }}
+          onClick={() => done("`onClickCapture` was not called")}
+        />
+      ) as HTMLButtonElement
+      button.click()
+    })
+    it("uses `element.on...` properties", () => {
+      const button = (<button onClick={() => void 0} />) as HTMLButtonElement
+      expect(button.onclick).to.be.a("function")
+    })
+    it("uses addEventListener", () => {
+      const button = (<button onCustomEvent={() => void 0} />) as HTMLButtonElement
+      // @ts-expect-error checking not existing property
+      expect(button.oncustomevent).to.not.be.a("function")
+      // @ts-expect-error checking not existing property
+      expect(button.customevent).to.not.be.a("function")
+    })
+    it("supports custom events", done => {
+      const button = (<button onCustomEvent={() => done()} />) as HTMLButtonElement
+      button.dispatchEvent(new window.Event("customevent"))
+    })
+    it("supports event listeners using `on` attribute", done => {
+      const button = (<button on={{ click: () => done() }} />) as HTMLButtonElement
+      button.click()
+    })
+    it("supports capture event listeners using `onCapture` attribute", done => {
+      const button = (
+        <button
+          onCapture={{
+            click: event => {
+              event.stopImmediatePropagation()
+              done()
+            },
+          }}
+          onClick={() => done("`onCapture` was not called")}
+        />
+      ) as HTMLButtonElement
+      button.click()
+    })
+    it("supports custom events using `on` attribute", done => {
+      const button = (<button on={{ CustomEvent: () => done() }} />) as HTMLButtonElement
+      button.dispatchEvent(new window.Event("CustomEvent"))
+    })
   })
 
   describe("forwardRef", () => {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -327,9 +327,126 @@ export type DetailedHTMLProps<E extends HTMLAttributes<T>, T> = AttrWithRef<T> &
 
 export interface SVGProps<T> extends SVGAttributes<T>, AttrWithRef<T> {}
 
+interface EventHandlers<T> {
+  // Clipboard Events
+  copy?: ClipboardEventHandler<T> | undefined
+  cut?: ClipboardEventHandler<T> | undefined
+  paste?: ClipboardEventHandler<T> | undefined
+
+  // Composition Events
+  compositionend?: CompositionEventHandler<T> | undefined
+  compositionstart?: CompositionEventHandler<T> | undefined
+  compositionupdate?: CompositionEventHandler<T> | undefined
+
+  // Focus Events
+  focus?: FocusEventHandler<T> | undefined
+  blur?: FocusEventHandler<T> | undefined
+
+  // Form Events
+  change?: FormEventHandler<T> | undefined
+  beforeinput?: FormEventHandler<T> | undefined
+  input?: FormEventHandler<T> | undefined
+  reset?: FormEventHandler<T> | undefined
+  submit?: FormEventHandler<T> | undefined
+  invalid?: FormEventHandler<T> | undefined
+
+  // Image Events
+  load?: ReactEventHandler<T> | undefined
+  error?: ReactEventHandler<T> | undefined // also a Media Event
+
+  // Keyboard Events
+  keydown?: KeyboardEventHandler<T> | undefined
+  keypress?: KeyboardEventHandler<T> | undefined
+  keyup?: KeyboardEventHandler<T> | undefined
+
+  // Media Events
+  abort?: ReactEventHandler<T> | undefined
+  canplay?: ReactEventHandler<T> | undefined
+  canplaythrough?: ReactEventHandler<T> | undefined
+  durationchange?: ReactEventHandler<T> | undefined
+  emptied?: ReactEventHandler<T> | undefined
+  encrypted?: ReactEventHandler<T> | undefined
+  ended?: ReactEventHandler<T> | undefined
+  loadeddata?: ReactEventHandler<T> | undefined
+  loadedmetadata?: ReactEventHandler<T> | undefined
+  loadstart?: ReactEventHandler<T> | undefined
+  pause?: ReactEventHandler<T> | undefined
+  play?: ReactEventHandler<T> | undefined
+  playing?: ReactEventHandler<T> | undefined
+  progress?: ReactEventHandler<T> | undefined
+  ratechange?: ReactEventHandler<T> | undefined
+  seeked?: ReactEventHandler<T> | undefined
+  seeking?: ReactEventHandler<T> | undefined
+  stalled?: ReactEventHandler<T> | undefined
+  suspend?: ReactEventHandler<T> | undefined
+  timeupdate?: ReactEventHandler<T> | undefined
+  volumechange?: ReactEventHandler<T> | undefined
+  waiting?: ReactEventHandler<T> | undefined
+
+  // MouseEvents
+  auxclick?: MouseEventHandler<T> | undefined
+  click?: MouseEventHandler<T> | undefined
+  contextmenu?: MouseEventHandler<T> | undefined
+  doubleclick?: MouseEventHandler<T> | undefined
+  drag?: DragEventHandler<T> | undefined
+  dragend?: DragEventHandler<T> | undefined
+  dragenter?: DragEventHandler<T> | undefined
+  dragexit?: DragEventHandler<T> | undefined
+  dragleave?: DragEventHandler<T> | undefined
+  dragover?: DragEventHandler<T> | undefined
+  dragstart?: DragEventHandler<T> | undefined
+  drop?: DragEventHandler<T> | undefined
+  mousedown?: MouseEventHandler<T> | undefined
+  mouseenter?: MouseEventHandler<T> | undefined
+  mouseleave?: MouseEventHandler<T> | undefined
+  mousemove?: MouseEventHandler<T> | undefined
+  mouseout?: MouseEventHandler<T> | undefined
+  mouseover?: MouseEventHandler<T> | undefined
+  mouseup?: MouseEventHandler<T> | undefined
+
+  // Selection Events
+  select?: ReactEventHandler<T> | undefined
+
+  // Touch Events
+  touchcancel?: TouchEventHandler<T> | undefined
+  touchend?: TouchEventHandler<T> | undefined
+  touchmove?: TouchEventHandler<T> | undefined
+  touchstart?: TouchEventHandler<T> | undefined
+
+  // Pointer Events
+  pointerdown?: PointerEventHandler<T> | undefined
+  pointermove?: PointerEventHandler<T> | undefined
+  pointerup?: PointerEventHandler<T> | undefined
+  pointercancel?: PointerEventHandler<T> | undefined
+  pointerenter?: PointerEventHandler<T> | undefined
+  pointerleave?: PointerEventHandler<T> | undefined
+  pointerover?: PointerEventHandler<T> | undefined
+  pointerout?: PointerEventHandler<T> | undefined
+
+  // UI Events
+  scroll?: UIEventHandler<T> | undefined
+
+  // Wheel Events
+  wheel?: WheelEventHandler<T> | undefined
+
+  // Animation Events
+  animationstart?: AnimationEventHandler<T> | undefined
+  animationend?: AnimationEventHandler<T> | undefined
+  animationiteration?: AnimationEventHandler<T> | undefined
+
+  // Transition Events
+  transitionend?: TransitionEventHandler<T> | undefined
+
+  // Custom events
+  [K: string]: ReactEventHandler<T> | undefined
+}
+
 export interface DOMAttributes<T> {
   children?: ReactNode | undefined
   dangerouslySetInnerHTML?: { __html: string } | undefined
+
+  on?: EventHandlers<T> | undefined
+  onCapture?: EventHandlers<T> | undefined
 
   // Clipboard Events
   onCopy?: ClipboardEventHandler<T> | undefined


### PR DESCRIPTION
### Support capture events

Events like `onClickCapture` are present in typings, but weren't working. PR add support for Capture variants.

### Fix custom events

Currently custom events are not working, seems like `if` was improperly copied in #38 

https://github.com/proteriax/jsx-dom/blob/35d58db68c783d3ab2f7a84abec90bc5f22a92a6/src/jsx-dom.ts#L298-L306

This PR brings back `addEventListener`. If it'd working properly before, this would also introduce breaking change - now events are registered as lowercase and without on, but custom events were not working anyway (`onCustomEvent` was assigned to `element.oncustomevent` instead of calling `addEventListener`).

### Support `on`/`onCapture`

To properly support custom event I'm proposing 2 new properties `on` and `onCapture`. Every key is added as-is, so user have full control of event name. Standard events are supported in lowercase form - as expected. These are always registered using `addEventListener` - this is good compromise for people who don't want to use `element.onclick` properties. `onClick` handlers are left for people like OP from #17 . Also this should fully satisfy #33


Look at tests for examples.