### PR TITLE
feat/AllowCamelCaseCustomEvent: add logic in jsx-dom.ts

### DIFF
--- a/src/jsx-dom.ts
+++ b/src/jsx-dom.ts
@@ -351,7 +351,24 @@ function attribute(key: string, value: any, node: Element & HTMLOrSVGElement) {
       } else if (useCapture) {
         node.addEventListener(attribute.substring(2, attribute.length - 7), value, true)
       } else {
-        node.addEventListener(attribute.substring(2), value)
+        let eventName;
+        if (attribute in window) {
+          // standard event
+          // the JSX attribute could have been "onMouseOver" and the
+          // member name "onmouseover" is on the window's prototype
+          // so let's add the listener "mouseover", which is all lowercased
+          let standardEventName = attribute.substring(2);
+          eventName = standardEventName;
+        } else {
+          // custom event
+          // the JSX attribute could have been "onMyCustomEvent"
+          // so let's trim off the "on" prefix and lowercase the first character
+          // and add the listener "myCustomEvent"
+          // except for the first character, we keep the event name case
+          let cutomEventName = attribute[2] + key.slice(3);
+          eventName = cutomEventName;
+        }
+        node.addEventListener(eventName, value)
       }
     }
   } else if (isObject(value)) {

--- a/test/test-main.tsx
+++ b/test/test-main.tsx
@@ -451,11 +451,11 @@ describe("jsx-dom", () => {
       // @ts-expect-error checking not existing property
       expect(button.oncustomevent).to.not.be.a("function")
       // @ts-expect-error checking not existing property
-      expect(button.customevent).to.not.be.a("function")
+      expect(button.customEvent).to.not.be.a("function")
     })
     it("supports custom events", done => {
       const button = (<button onCustomEvent={() => done()} />) as HTMLButtonElement
-      button.dispatchEvent(new window.Event("customevent"))
+      button.dispatchEvent(new window.Event("customEvent"))
     })
     it("supports event listeners using `on` attribute", done => {
       const button = (<button on={{ click: () => done() }} />) as HTMLButtonElement


### PR DESCRIPTION
# Related with issue "Custom events always add in lowercas #81 "

***HOW:***
We consider an event to be a browser's own event if, when converted to lowercase, it belongs to the Window Event Attributes set.

E.g. onclick, onClick, onmouseover, onMouseOver, etc. Window Event Attributes => https://www.w3schools.com/tags/ref_eventattributes.asp

Otherwise we consider it a custom event.  E.g. onMyCustomEvent

So let's trim the prefix "on" and lowercase the first character and add the listener "myCustomEvent". except for the first character, we keep the event name case