### PR TITLE
Added special handling for React's onDoubleClick event.

### DIFF
--- a/src/jsx-dom.ts
+++ b/src/jsx-dom.ts
@@ -349,9 +349,9 @@ function attribute(key: string, value: any, node: Element & HTMLOrSVGElement) {
       let attribute = key.toLowerCase()
       const useCapture = attribute.endsWith("capture")
       if (attribute === "ondoubleclick") {
-        attribute = "ondblclick";
+        attribute = "ondblclick"
       } else if (useCapture && attribute === "ondoubleclickcapture") {
-        attribute = "ondblclickcapture";
+        attribute = "ondblclickcapture"
       }
 
       if (!useCapture && node[attribute] === null) {

--- a/src/jsx-dom.ts
+++ b/src/jsx-dom.ts
@@ -346,12 +346,13 @@ function attribute(key: string, value: any, node: Element & HTMLOrSVGElement) {
 
   if (isFunction(value)) {
     if (key[0] === "o" && key[1] === "n") {
-      var attribute = key.toLowerCase()
+      let attribute = key.toLowerCase()
       const useCapture = attribute.endsWith("capture")
-      if (attribute == "ondoubleclick")
+      if (attribute === "ondoubleclick") {
         attribute = "ondblclick";
-      else if (useCapture && attribute == "ondoubleclickcapture")
+      } else if (useCapture && attribute === "ondoubleclickcapture") {
         attribute = "ondblclickcapture";
+      }
 
       if (!useCapture && node[attribute] === null) {
         // use property when possible PR #17

--- a/src/jsx-dom.ts
+++ b/src/jsx-dom.ts
@@ -139,7 +139,7 @@ function initComponentClass(Class: ComponentClass, attr, children) {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function jsx(tag: any, { children, ...attr }, key?: string) {
+export function jsx(tag: any, { children, ...attr }, _key?: string) {
   if (__FULL_BUILD__ && !attr.namespaceURI && svg[tag] === 0) {
     attr = { ...attr, namespaceURI: SVGNamespace }
   }
@@ -346,8 +346,12 @@ function attribute(key: string, value: any, node: Element & HTMLOrSVGElement) {
 
   if (isFunction(value)) {
     if (key[0] === "o" && key[1] === "n") {
-      const attribute = key.toLowerCase()
+      var attribute = key.toLowerCase()
       const useCapture = attribute.endsWith("capture")
+      if (attribute == "ondoubleclick")
+        attribute = "ondblclick";
+      else if (useCapture && attribute == "ondoubleclickcapture")
+        attribute = "ondblclickcapture";
 
       if (!useCapture && node[attribute] === null) {
         // use property when possible PR #17

--- a/test/test-main.tsx
+++ b/test/test-main.tsx
@@ -487,6 +487,22 @@ describe("jsx-dom", () => {
       const button = (<button on={{ CustomEvent: () => done() }} />) as HTMLButtonElement
       button.dispatchEvent(new window.Event("CustomEvent"))
     })
+    it("maps onDoubleClick to dblclick event", done => {
+      const button = (<button onDoubleClick={() => done()} />) as HTMLButtonElement
+      button.dispatchEvent(new window.Event('dblclick'));
+    });
+    it("maps onDblClick to dblclick event", done => {
+      const button = (<button onDblClick={() => done()} />) as HTMLButtonElement
+      button.dispatchEvent(new window.Event('dblclick'));
+    });
+    it("maps onDoubleClickCapture to dblclick event", done => {
+      const button = (<button onDoubleClickCapture={() => done()} />) as HTMLButtonElement
+      button.dispatchEvent(new window.Event('dblclick'));
+    });
+    it("maps onDblClickCapture to dblclick event", done => {
+      const button = (<button onDblClickCapture={() => done()} />) as HTMLButtonElement
+      button.dispatchEvent(new window.Event('dblclick'));
+    });
   })
 
   describe("forwardRef", () => {

--- a/test/test-main.tsx
+++ b/test/test-main.tsx
@@ -489,20 +489,20 @@ describe("jsx-dom", () => {
     })
     it("maps onDoubleClick to dblclick event", done => {
       const button = (<button onDoubleClick={() => done()} />) as HTMLButtonElement
-      button.dispatchEvent(new window.Event('dblclick'));
-    });
+      button.dispatchEvent(new window.Event("dblclick"))
+    })
     it("maps onDblClick to dblclick event", done => {
       const button = (<button onDblClick={() => done()} />) as HTMLButtonElement
-      button.dispatchEvent(new window.Event('dblclick'));
-    });
+      button.dispatchEvent(new window.Event("dblclick"))
+    })
     it("maps onDoubleClickCapture to dblclick event", done => {
       const button = (<button onDoubleClickCapture={() => done()} />) as HTMLButtonElement
-      button.dispatchEvent(new window.Event('dblclick'));
-    });
+      button.dispatchEvent(new window.Event("dblclick"))
+    })
     it("maps onDblClickCapture to dblclick event", done => {
       const button = (<button onDblClickCapture={() => done()} />) as HTMLButtonElement
-      button.dispatchEvent(new window.Event('dblclick'));
-    });
+      button.dispatchEvent(new window.Event("dblclick"))
+    })
   })
 
   describe("forwardRef", () => {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -572,6 +572,8 @@ export interface DOMAttributes<T> {
   onClickCapture?: MouseEventHandler<T> | undefined
   onContextMenu?: MouseEventHandler<T> | undefined
   onContextMenuCapture?: MouseEventHandler<T> | undefined
+  onDblClick?: MouseEventHandler<T> | undefined
+  onDblClickCapture?: MouseEventHandler<T> | undefined
   onDoubleClick?: MouseEventHandler<T> | undefined
   onDoubleClickCapture?: MouseEventHandler<T> | undefined
   onDrag?: DragEventHandler<T> | undefined


### PR DESCRIPTION
React has a onDoubleClick event but afaik it is eventually mapped to dblclick DOM event (https://developer.mozilla.org/en-US/docs/Web/API/Element/dblclick_event). 

Preact Compat has special handling for onDoubleClick (https://github.com/preactjs/preact/blob/87024e8480c6a60bf114d6c69791a87cec0c553a/compat/src/render.js#L146).

Without this patch, jsx-dom considers onDoubleClick as a custom event, and attaches the event handler as a custom event to "doubleClick" event, which does not exist.