### PR TITLE
Workaround for class component refs

### DIFF
--- a/src/jsx-dom.ts
+++ b/src/jsx-dom.ts
@@ -118,7 +118,7 @@ export function Fragment(attr: { children: JSX.Element | JSX.Element[] }) {
 }
 
 export class Component {
-  constructor(readonly props: any) { }
+  constructor(readonly props: any) {}
 
   render() {
     return null
@@ -191,7 +191,7 @@ export function createElement(tag: any, attr: any, ...children: any[]) {
   attr = attr || {}
 
   if (attr.children != null && !children.length) {
-    ; ({ children, ...attr } = attr)
+    ;({ children, ...attr } = attr)
   }
 
   return jsx(tag, { ...attr, children }, attr.key)

--- a/src/jsx-dom.ts
+++ b/src/jsx-dom.ts
@@ -118,7 +118,7 @@ export function Fragment(attr: { children: JSX.Element | JSX.Element[] }) {
 }
 
 export class Component {
-  constructor(readonly props: any) {}
+  constructor(readonly props: any) { }
 
   render() {
     return null
@@ -134,7 +134,9 @@ export class Component {
 function initComponentClass(Class: ComponentClass, attr, children) {
   attr = { ...attr, children }
   const instance = new Class(attr)
-  return instance.render()
+  var result = instance.render();
+  attachRef(attr.ref, instance);
+  return result;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -189,7 +191,7 @@ export function createElement(tag: any, attr: any, ...children: any[]) {
   attr = attr || {}
 
   if (attr.children != null && !children.length) {
-    ;({ children, ...attr } = attr)
+    ; ({ children, ...attr } = attr)
   }
 
   return jsx(tag, { ...attr, children }, attr.key)

--- a/src/ref.ts
+++ b/src/ref.ts
@@ -4,7 +4,7 @@ interface Ref<T = Node> {
   current: null | T
 }
 
-export function createRef<T extends Node = Node>(): Ref<T> {
+export function createRef<T = Node>(): Ref<T> {
   return Object.seal({ current: null })
 }
 

--- a/test/hooks.test.tsx
+++ b/test/hooks.test.tsx
@@ -30,6 +30,27 @@ describe("hooks", () => {
     expect(ref2.current).toHaveProperty("tagName", "INPUT")
   })
 
+  it("supports useRef with class components", () => {
+    class MyButton extends React.Component {
+      render() {
+        return <button type="button"></button>
+      }
+    }
+
+    const ref = React.useRef<MyButton>()
+    expect(ref).toHaveProperty("current", null)
+
+    const div = (
+      <div>
+        <MyButton ref={ref} />
+      </div>
+    )
+    expect(ref).not.toBeNull()
+    expect(ref.current).not.toBeNull()
+    expect(ref.current instanceof MyButton).toBe(true);
+    expect(div.children[0] instanceof HTMLButtonElement).toBe(true)
+  })
+
   it("supports useClassList", () => {
     const cls = React.useClassList()
     cls.add("me")


### PR DESCRIPTION
As noted in the issue https://github.com/alex-kinokon/jsx-dom/issues/104, attachRef is not called anywhere in jsx-dom code for class components unless I am missing something. In React/Preact refs are called during mounting, but no such phase exists in jsx-dom. So I think attachRef should be called in initClassComponent method.