### PR TITLE
Add missing .js extension to export in "jsx-dev-runtime.js"

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -137,10 +137,9 @@ export async function build({ targetDir, format, packageName }: BuildOptions) {
     fs.writeFile(
       resolve(OUT_DIR, "jsx-dev-runtime.js"),
       format === "esm"
-        ? /* javascript */ `export * from "./jsx-runtime";`
+        ? /* javascript */ `export * from "./jsx-runtime.js";`
         : /* javascript */ `module.exports = require("./jsx-runtime");`
     ),
-
     buildRollup("styled.macro", {
       moduleFormat: "cjs",
       cjsExtension: true,
@@ -155,9 +154,10 @@ export async function build({ targetDir, format, packageName }: BuildOptions) {
       outputDir: OUT_DIR_MIN,
       inject: { "./jsx-dom": `${packageName}/min`, delimiters: ["", ""] },
     }),
+    reexport("jsx-dev-runtime.js", OUT_DIR_MIN, "./jsx-runtime.js"),
     reexport("index.d.ts", OUT_DIR_MIN, "../index"),
     reexport("jsx-runtime.d.ts", OUT_DIR_MIN, "./index", jsxRuntimeExports),
-    reexport("jsx-runtime.d.ts", OUT_DIR, "./index", jsxRuntimeExports),
+    reexport("jsx-runtime.d.ts", OUT_DIR, "./index", jsxRuntimeExports)
   ])
 }
 


### PR DESCRIPTION
The following statement in jsx-dev-runtime.js fails with vitest:

```js
export * from "./jsx-runtime";
```

Extensions in import statements are normally mandatory in esm and it fails in some environments like vitest with default configuration:

```log
Error: Cannot find module 
'...\node_modules\.pnpm\jsx-dom@8.1.5\node_modules\jsx-dom\jsx-runtime' 
imported from 
...\node_modules\.pnpm\jsx-dom@8.1.5\node_modules\jsx-dom\jsx-dev-runtime.js
```

Also added a "min/jsx-dev-runtime.js" as it is causing vitest to fail resolving it when jsx-dom/min is used as automatic runtime:

```log
Error: Failed to resolve import "jsx-dom/min/jsx-dev-runtime" from "src/base/dialogs.tsx". Does the file exist?
  Plugin: vite:import-analysis
  File: .../src/base/dialogs.tsx:431:49
  1  |  import { jsxDEV } from "jsx-dom/min/jsx-dev-runtime";
```


These two does not cause an issue with esbuild / swc / jest combination as I think they try .js extension and non-dev runtime unlike vitest does by default.