### PR TITLE
Resolve "Directory import '.../jsx-dom/min' is not supported resolvin…

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -150,11 +150,8 @@ export async function build({ targetDir, format, packageName }: BuildOptions) {
     buildRollup("jsx-runtime", {
       inject: { "./jsx-dom": packageName, delimiters: ["", ""] },
     }),
-    buildRollup("jsx-runtime", {
-      outputDir: OUT_DIR_MIN,
-      inject: { "./jsx-dom": `${packageName}/min`, delimiters: ["", ""] },
-    }),
     reexport("jsx-dev-runtime.js", OUT_DIR_MIN, "./jsx-runtime.js"),
+    reexport("jsx-runtime.js", OUT_DIR_MIN, "./index.js", jsxRuntimeExports),
     reexport("index.d.ts", OUT_DIR_MIN, "../index"),
     reexport("jsx-runtime.d.ts", OUT_DIR_MIN, "./index", jsxRuntimeExports),
     reexport("jsx-runtime.d.ts", OUT_DIR, "./index", jsxRuntimeExports),


### PR DESCRIPTION
The prior pull request fixed the issue with jsx-dev-runtime for both min and full ESM version but still getting following when using jsx-dom/min:

```
Resolve "Directory import '...../jsx-dom/min' is not supported resolving ES modules imported from ...../jsx-dom/min/jsx-runtime.js" 
```

This is caused by "export { Fragment, jsx, jsx as jsxDEV, jsx as jsxs } from "jsx-dom/min";" as it should have /index.js at the end for ESM.
